### PR TITLE
fix(templates+schema): fix numeric-input coercion and template update UX (#3 #4 #5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to `mailchimp-mcp-server` are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.7 — 2026-04-21
+
+### Fixed
+
+- **Numeric tool inputs no longer reject string-encoded integers.** Every input-side `z.number().int()` is now `z.coerce.number().int()` across the ten tools that take numeric IDs, page counts, or offsets (`mailchimp_templates`, `mailchimp_merge_fields`, `mailchimp_segments`, `mailchimp_subscribers`, `mailchimp_reports`, `mailchimp_audiences`, `mailchimp_campaigns`, `mailchimp_send_campaign`, `mailchimp_replicate_campaign`, `mailchimp_search`). Clients that marshal integers as JSON strings (Claude Desktop and some bridges do this for int-shaped fields) previously hit `expected: "number", received: "string"` before the handler ran; now the value is coerced and validated normally. Output schemas are unchanged. ([#3](https://github.com/cyanheads/mailchimp-mcp-server/issues/3))
+- **`mailchimp_templates` (`operation: update`) now returns an actionable validation error** when no `name`/`html`/`folderId` is supplied. The previous message was a generic "At least one of …"; the new message explains the full-HTML-replacement model and points users to the `mailchimp_campaigns` / `mailchimp_send_campaign` `templateSections` workflow for per-section edits. ([#5](https://github.com/cyanheads/mailchimp-mcp-server/issues/5))
+
+### Changed
+
+- **`templateSections` field on the three campaign-content tools** (`mailchimp_send_campaign`, `mailchimp_campaigns` `set-content`, `mailchimp_replicate_campaign` `contentOverride`) now carries a single shared description that documents: keys (edit-region IDs from `mc:edit="…"` in the template HTML, or section IDs from `mailchimp_templates get-default-content`), values (HTML strings), applicability (`templateId` must also be set), a concrete example, and the "non-drag-and-drop templates often return an empty sections map — read the template HTML directly in that case" caveat. `mailchimp_replicate_campaign`'s `templateSections` previously had no `.describe()` at all. Extracted into `src/mcp-server/tools/shared/template-sections-doc.ts` so the three tools cannot drift. ([#4](https://github.com/cyanheads/mailchimp-mcp-server/issues/4))
+- **`mailchimp_templates` tool description** now explicitly states "Per-section editing is not supported here", explains the full-HTML replacement model, and cross-references the campaign workflow for per-section overrides. ([#5](https://github.com/cyanheads/mailchimp-mcp-server/issues/5))
+- **`mailchimp_templates get-default-content` `format()` output** now notes when the sections map is empty (common for user-uploaded HTML templates using `mc:edit`) and points the agent to read the template HTML directly. ([#5](https://github.com/cyanheads/mailchimp-mcp-server/issues/5))
+
+### Added
+
+- `tests/tools/mailchimp-templates.test.ts` — full handler + format + metadata coverage for the templates tool, including string-id coercion regression, name-only / html-only / empty-update paths, and the empty-sections format hint.
+- `tests/tools/input-coercion.test.ts` — pins `z.coerce.number()` behavior across every tool that was changed, so a future edit dropping the `.coerce` gets caught immediately.
+- `tests/tools/template-sections-doc.test.ts` — asserts the shared `TEMPLATE_SECTIONS_DOC` content (mc:edit, get-default-content, example, drag-and-drop caveat) and that all three campaign-content tools surface it in their emitted JSON Schema. 95 tests total (up from 50).
+
 ## 0.2.6 — 2026-04-21
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Agent Protocol
 
 **Server:** mailchimp-mcp-server
-**Version:** 0.2.6
+**Version:** 0.2.7
 **Framework:** [@cyanheads/mcp-ts-core](https://www.npmjs.com/package/@cyanheads/mcp-ts-core)
 **Surface:** 17 tools · 4 resources · 1 prompt · 1 service (`mailchimp`)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <div align="center">
 
-[![npm](https://img.shields.io/npm/v/@cyanheads/mailchimp-mcp-server?style=flat-square&logo=npm&logoColor=white)](https://www.npmjs.com/package/@cyanheads/mailchimp-mcp-server) [![Version](https://img.shields.io/badge/Version-0.2.6-blue.svg?style=flat-square)](./CHANGELOG.md) [![Framework](https://img.shields.io/badge/Built%20on-@cyanheads/mcp--ts--core-259?style=flat-square)](https://www.npmjs.com/package/@cyanheads/mcp-ts-core) [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-^1.29.0-green.svg?style=flat-square)](https://modelcontextprotocol.io/) 
+[![npm](https://img.shields.io/npm/v/@cyanheads/mailchimp-mcp-server?style=flat-square&logo=npm&logoColor=white)](https://www.npmjs.com/package/@cyanheads/mailchimp-mcp-server) [![Version](https://img.shields.io/badge/Version-0.2.7-blue.svg?style=flat-square)](./CHANGELOG.md) [![Framework](https://img.shields.io/badge/Built%20on-@cyanheads/mcp--ts--core-259?style=flat-square)](https://www.npmjs.com/package/@cyanheads/mcp-ts-core) [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-^1.29.0-green.svg?style=flat-square)](https://modelcontextprotocol.io/) 
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-orange.svg?style=flat-square)](./LICENSE) [![TypeScript](https://img.shields.io/badge/TypeScript-^6.0.3-3178C6.svg?style=flat-square)](https://www.typescriptlang.org/) [![Bun](https://img.shields.io/badge/Bun-v1.3.2-blueviolet.svg?style=flat-square)](https://bun.sh/)
 

--- a/docs/tree.md
+++ b/docs/tree.md
@@ -1,6 +1,6 @@
 # mailchimp-mcp-server - Directory Structure
 
-Generated on: 2026-04-20 19:56:30
+Generated on: 2026-04-21 21:53:43
 
 ```text
 mailchimp-mcp-server/
@@ -46,6 +46,8 @@ mailchimp-mcp-server/
 │   │   └── SKILL.md
 │   ├── api-errors/
 │   │   └── SKILL.md
+│   ├── api-linter/
+│   │   └── SKILL.md
 │   ├── api-services/
 │   │   ├── references/
 │   │   │   ├── graph.md
@@ -63,8 +65,6 @@ mailchimp-mcp-server/
 │   ├── api-workers/
 │   │   └── SKILL.md
 │   ├── design-mcp-server/
-│   │   └── SKILL.md
-│   ├── devcheck/
 │   │   └── SKILL.md
 │   ├── field-test/
 │   │   └── SKILL.md
@@ -101,25 +101,27 @@ mailchimp-mcp-server/
 │   │   │       ├── mailchimp-campaign-report.resource.ts
 │   │   │       └── mailchimp-campaign.resource.ts
 │   │   └── tools/
-│   │       └── definitions/
-│   │           ├── index.ts
-│   │           ├── mailchimp-account.tool.ts
-│   │           ├── mailchimp-audience-overview.tool.ts
-│   │           ├── mailchimp-audiences.tool.ts
-│   │           ├── mailchimp-campaign-report.tool.ts
-│   │           ├── mailchimp-campaigns.tool.ts
-│   │           ├── mailchimp-find-subscriber.tool.ts
-│   │           ├── mailchimp-import-subscribers.tool.ts
-│   │           ├── mailchimp-merge-fields.tool.ts
-│   │           ├── mailchimp-playbook.tool.ts
-│   │           ├── mailchimp-replicate-campaign.tool.ts
-│   │           ├── mailchimp-reports.tool.ts
-│   │           ├── mailchimp-search.tool.ts
-│   │           ├── mailchimp-segments.tool.ts
-│   │           ├── mailchimp-send-campaign.tool.ts
-│   │           ├── mailchimp-subscribers.tool.ts
-│   │           ├── mailchimp-templates.tool.ts
-│   │           └── mailchimp-upsert-subscriber.tool.ts
+│   │       ├── definitions/
+│   │       │   ├── index.ts
+│   │       │   ├── mailchimp-account.tool.ts
+│   │       │   ├── mailchimp-audience-overview.tool.ts
+│   │       │   ├── mailchimp-audiences.tool.ts
+│   │       │   ├── mailchimp-campaign-report.tool.ts
+│   │       │   ├── mailchimp-campaigns.tool.ts
+│   │       │   ├── mailchimp-find-subscriber.tool.ts
+│   │       │   ├── mailchimp-import-subscribers.tool.ts
+│   │       │   ├── mailchimp-merge-fields.tool.ts
+│   │       │   ├── mailchimp-playbook.tool.ts
+│   │       │   ├── mailchimp-replicate-campaign.tool.ts
+│   │       │   ├── mailchimp-reports.tool.ts
+│   │       │   ├── mailchimp-search.tool.ts
+│   │       │   ├── mailchimp-segments.tool.ts
+│   │       │   ├── mailchimp-send-campaign.tool.ts
+│   │       │   ├── mailchimp-subscribers.tool.ts
+│   │       │   ├── mailchimp-templates.tool.ts
+│   │       │   └── mailchimp-upsert-subscriber.tool.ts
+│   │       └── shared/
+│   │           └── template-sections-doc.ts
 │   ├── services/
 │   │   └── mailchimp/
 │   │       ├── mailchimp-service.ts
@@ -137,8 +139,11 @@ mailchimp-mcp-server/
 │   │       ├── mailchimp-service.test.ts
 │   │       └── normalize.test.ts
 │   └── tools/
+│       ├── input-coercion.test.ts
 │       ├── mailchimp-campaign-report.test.ts
-│       └── mailchimp-playbook.test.ts
+│       ├── mailchimp-playbook.test.ts
+│       ├── mailchimp-templates.test.ts
+│       └── template-sections-doc.test.ts
 ├── .dockerignore
 ├── .env.example
 ├── .gitignore

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyanheads/mailchimp-mcp-server",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "mcpName": "io.github.cyanheads/mailchimp-mcp-server",
   "description": "Draft, test, and send Mailchimp campaigns straight from your MCP client — with audience management, subscriber CRUD, and post-send analytics behind safe-by-default send gates. STDIO or Streamable HTTP.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,14 +6,14 @@
     "url": "https://github.com/cyanheads/mailchimp-mcp-server",
     "source": "github"
   },
-  "version": "0.2.6",
+  "version": "0.2.7",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@cyanheads/mailchimp-mcp-server",
       "runtimeHint": "bun",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "packageArguments": [
         { "type": "positional", "value": "run" },
         { "type": "positional", "value": "start:stdio" }
@@ -69,7 +69,7 @@
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@cyanheads/mailchimp-mcp-server",
       "runtimeHint": "bun",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "packageArguments": [
         { "type": "positional", "value": "run" },
         { "type": "positional", "value": "start:http" }

--- a/src/mcp-server/tools/definitions/mailchimp-audiences.tool.ts
+++ b/src/mcp-server/tools/definitions/mailchimp-audiences.tool.ts
@@ -83,14 +83,14 @@ const InputSchema = z.object({
   notifyOnSubscribe: z.string().optional().describe('Email to notify on subscribe.'),
   notifyOnUnsubscribe: z.string().optional().describe('Email to notify on unsubscribe.'),
   visibility: z.enum(['pub', 'prv']).optional().describe('`pub` (public) or `prv` (private).'),
-  count: z
+  count: z.coerce
     .number()
     .int()
     .min(1)
     .max(1000)
     .default(10)
     .describe('Page size for list-style reads. Max 1000 (Mailchimp cap).'),
-  offset: z.number().int().min(0).default(0).describe('Offset for list-style reads.'),
+  offset: z.coerce.number().int().min(0).default(0).describe('Offset for list-style reads.'),
   signupFormConfig: z
     .object({
       type: z

--- a/src/mcp-server/tools/definitions/mailchimp-campaigns.tool.ts
+++ b/src/mcp-server/tools/definitions/mailchimp-campaigns.tool.ts
@@ -9,6 +9,7 @@
 
 import { tool, z } from '@cyanheads/mcp-ts-core';
 import { validationError } from '@cyanheads/mcp-ts-core/errors';
+import { TEMPLATE_SECTIONS_DOC } from '@/mcp-server/tools/shared/template-sections-doc.js';
 import { getMailchimpService } from '@/services/mailchimp/mailchimp-service.js';
 import type { Campaign } from '@/services/mailchimp/types.js';
 
@@ -37,7 +38,7 @@ const CampaignTypeSchema = z
 
 const RecipientsSchema = z.object({
   listId: z.string().describe('Audience (list) ID.'),
-  savedSegmentId: z
+  savedSegmentId: z.coerce
     .number()
     .int()
     .optional()
@@ -54,17 +55,22 @@ const SettingsSchema = z.object({
   authenticate: z.boolean().optional(),
   autoFooter: z.boolean().optional(),
   inlineCss: z.boolean().optional(),
-  templateId: z.number().int().optional(),
+  templateId: z.coerce
+    .number()
+    .int()
+    .optional()
+    .describe('Saved-template ID to base this campaign on.'),
 });
 
 const ContentSchema = z.object({
   html: z.string().optional(),
   plainText: z.string().optional(),
-  templateId: z.number().int().optional(),
-  templateSections: z
-    .record(z.string(), z.unknown())
+  templateId: z.coerce
+    .number()
+    .int()
     .optional()
-    .describe('Per-section overrides when using `templateId`.'),
+    .describe('Saved-template ID to render this campaign from.'),
+  templateSections: z.record(z.string(), z.unknown()).optional().describe(TEMPLATE_SECTIONS_DOC),
   archiveContent: z.string().optional().describe('Base64-encoded zip or HTML archive.'),
   archiveType: z.string().optional(),
   url: z.string().optional().describe('Fetch HTML from a URL.'),
@@ -96,8 +102,14 @@ const InputSchema = z.object({
     .string()
     .optional()
     .describe('Filter `list` to campaigns sent before this ISO 8601 timestamp.'),
-  count: z.number().int().min(1).max(1000).default(10).describe('Page size for `list`. Max 1000.'),
-  offset: z.number().int().min(0).default(0).describe('Offset for `list` pagination.'),
+  count: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(1000)
+    .default(10)
+    .describe('Page size for `list`. Max 1000.'),
+  offset: z.coerce.number().int().min(0).default(0).describe('Offset for `list` pagination.'),
 });
 
 const CampaignSummarySchema = z.object({

--- a/src/mcp-server/tools/definitions/mailchimp-merge-fields.tool.ts
+++ b/src/mcp-server/tools/definitions/mailchimp-merge-fields.tool.ts
@@ -35,7 +35,11 @@ const MergeFieldTypeSchema = z
 const InputSchema = z.object({
   operation: OperationSchema,
   audienceId: z.string().describe('Audience (list) ID.'),
-  mergeId: z.number().int().optional().describe('Merge-field ID. Required for `get` and `update`.'),
+  mergeId: z.coerce
+    .number()
+    .int()
+    .optional()
+    .describe('Merge-field ID. Required for `get` and `update`.'),
   name: z.string().optional().describe('Display name. Required for `create`.'),
   tag: z
     .string()
@@ -60,7 +64,7 @@ const InputSchema = z.object({
     .string()
     .optional()
     .describe('Help text shown next to the field on signup/profile forms.'),
-  displayOrder: z
+  displayOrder: z.coerce
     .number()
     .int()
     .optional()
@@ -69,8 +73,14 @@ const InputSchema = z.object({
     .record(z.string(), z.unknown())
     .optional()
     .describe('Merge-field options (e.g. choices for dropdown, date format for date).'),
-  count: z.number().int().min(1).max(1000).default(80).describe('Page size for `list`. Max 1000.'),
-  offset: z.number().int().min(0).default(0).describe('Offset for `list` pagination.'),
+  count: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(1000)
+    .default(80)
+    .describe('Page size for `list`. Max 1000.'),
+  offset: z.coerce.number().int().min(0).default(0).describe('Offset for `list` pagination.'),
 });
 
 const MergeFieldSummarySchema = z.object({

--- a/src/mcp-server/tools/definitions/mailchimp-replicate-campaign.tool.ts
+++ b/src/mcp-server/tools/definitions/mailchimp-replicate-campaign.tool.ts
@@ -7,6 +7,7 @@
 
 import { tool, z } from '@cyanheads/mcp-ts-core';
 import { validationError } from '@cyanheads/mcp-ts-core/errors';
+import { TEMPLATE_SECTIONS_DOC } from '@/mcp-server/tools/shared/template-sections-doc.js';
 import { getMailchimpService } from '@/services/mailchimp/mailchimp-service.js';
 
 const ModeSchema = z
@@ -17,10 +18,14 @@ const ModeSchema = z
 
 const ContentOverrideSchema = z
   .object({
-    html: z.string().optional(),
-    plainText: z.string().optional(),
-    templateId: z.number().int().optional(),
-    templateSections: z.record(z.string(), z.unknown()).optional(),
+    html: z.string().optional().describe('Full HTML body replacement.'),
+    plainText: z.string().optional().describe('Plaintext body replacement.'),
+    templateId: z.coerce
+      .number()
+      .int()
+      .optional()
+      .describe('Saved-template ID to render the replica from instead of the original content.'),
+    templateSections: z.record(z.string(), z.unknown()).optional().describe(TEMPLATE_SECTIONS_DOC),
   })
   .describe("Content replacement. Omit to keep the source campaign's content.");
 
@@ -54,7 +59,7 @@ const InputSchema = z.object({
     .string()
     .optional()
     .describe('New audience ID. Omit to keep the source audience.'),
-  segmentOverride: z
+  segmentOverride: z.coerce
     .number()
     .int()
     .optional()

--- a/src/mcp-server/tools/definitions/mailchimp-reports.tool.ts
+++ b/src/mcp-server/tools/definitions/mailchimp-reports.tool.ts
@@ -64,14 +64,14 @@ const InputSchema = z.object({
     .string()
     .optional()
     .describe('Filter `list` to reports for campaigns sent after this ISO 8601 timestamp.'),
-  count: z
+  count: z.coerce
     .number()
     .int()
     .min(1)
     .max(1000)
     .default(20)
     .describe('Page size for list-style reads. Max 1000.'),
-  offset: z.number().int().min(0).default(0).describe('Offset for list-style pagination.'),
+  offset: z.coerce.number().int().min(0).default(0).describe('Offset for list-style pagination.'),
 });
 
 const ReportSummarySchema = z.object({

--- a/src/mcp-server/tools/definitions/mailchimp-search.tool.ts
+++ b/src/mcp-server/tools/definitions/mailchimp-search.tool.ts
@@ -20,7 +20,13 @@ const InputSchema = z.object({
     .string()
     .optional()
     .describe('Restrict member search to a single audience. Ignored for `scope: campaigns`.'),
-  includeTopN: z.number().int().min(1).max(100).default(10).describe('Max results to return.'),
+  includeTopN: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .default(10)
+    .describe('Max results to return.'),
 });
 
 const MemberMatchSchema = z.object({

--- a/src/mcp-server/tools/definitions/mailchimp-segments.tool.ts
+++ b/src/mcp-server/tools/definitions/mailchimp-segments.tool.ts
@@ -32,7 +32,7 @@ const SegmentOptionsSchema = z.object({
 const InputSchema = z.object({
   operation: OperationSchema,
   audienceId: z.string().describe('Audience (list) ID the segment belongs to.'),
-  segmentId: z
+  segmentId: z.coerce
     .number()
     .int()
     .optional()
@@ -59,8 +59,14 @@ const InputSchema = z.object({
     .optional()
     .describe('Emails to remove. Used by `batch-update-members`.'),
   type: z.enum(['saved', 'static', 'fuzzy']).optional().describe('Filter (for `list`).'),
-  count: z.number().int().min(1).max(1000).default(20).describe('Page size for list-style reads.'),
-  offset: z.number().int().min(0).default(0).describe('Offset for list-style reads.'),
+  count: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(1000)
+    .default(20)
+    .describe('Page size for list-style reads.'),
+  offset: z.coerce.number().int().min(0).default(0).describe('Offset for list-style reads.'),
 });
 
 const SegmentSummarySchema = z.object({

--- a/src/mcp-server/tools/definitions/mailchimp-send-campaign.tool.ts
+++ b/src/mcp-server/tools/definitions/mailchimp-send-campaign.tool.ts
@@ -9,6 +9,7 @@
 
 import { tool, z } from '@cyanheads/mcp-ts-core';
 import { validationError } from '@cyanheads/mcp-ts-core/errors';
+import { TEMPLATE_SECTIONS_DOC } from '@/mcp-server/tools/shared/template-sections-doc.js';
 import { getMailchimpService } from '@/services/mailchimp/mailchimp-service.js';
 
 const ModeSchema = z
@@ -21,13 +22,8 @@ const ContentSchema = z
   .object({
     html: z.string().optional().describe('Full HTML body. Mailchimp renders as-is.'),
     plainText: z.string().optional().describe('Plaintext body. Required for `type: plaintext`.'),
-    templateId: z.number().int().optional().describe('Template ID to use as the base.'),
-    templateSections: z
-      .record(z.string(), z.unknown())
-      .optional()
-      .describe(
-        'Per-section overrides when using `templateId` (Mailchimp drag-and-drop sections).',
-      ),
+    templateId: z.coerce.number().int().optional().describe('Template ID to use as the base.'),
+    templateSections: z.record(z.string(), z.unknown()).optional().describe(TEMPLATE_SECTIONS_DOC),
   })
   .describe('Campaign content. Provide at least one of html / plainText / templateId.');
 
@@ -45,7 +41,7 @@ const InputSchema = z.object({
     .enum(['regular', 'plaintext', 'rss'])
     .default('regular')
     .describe('Campaign type. Only `regular`/`plaintext`/`rss` are supported (A/B is paid).'),
-  segmentId: z
+  segmentId: z.coerce
     .number()
     .int()
     .optional()

--- a/src/mcp-server/tools/definitions/mailchimp-subscribers.tool.ts
+++ b/src/mcp-server/tools/definitions/mailchimp-subscribers.tool.ts
@@ -68,13 +68,19 @@ const InputSchema = z.object({
       "Tag names that should NOT be removed by `set-tags` even if absent from `tags`. Use this to protect static-segment memberships (Mailchimp stores them as tags) or any other 'sticky' tag you don't want the declarative sync to strip.",
     ),
   note: z.string().optional().describe('Note body. Required for `add-note`/`update-note`.'),
-  noteId: z
+  noteId: z.coerce
     .number()
     .int()
     .optional()
     .describe('Note ID. Required for `update-note`/`delete-note`.'),
-  count: z.number().int().min(1).max(1000).default(20).describe('Page size for list-style reads.'),
-  offset: z.number().int().min(0).default(0).describe('Offset for list-style reads.'),
+  count: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(1000)
+    .default(20)
+    .describe('Page size for list-style reads.'),
+  offset: z.coerce.number().int().min(0).default(0).describe('Offset for list-style reads.'),
 });
 
 const SubscriberSummarySchema = z.object({

--- a/src/mcp-server/tools/definitions/mailchimp-templates.tool.ts
+++ b/src/mcp-server/tools/definitions/mailchimp-templates.tool.ts
@@ -18,7 +18,7 @@ const OperationSchema = z
 
 const InputSchema = z.object({
   operation: OperationSchema,
-  templateId: z
+  templateId: z.coerce
     .number()
     .int()
     .optional()
@@ -36,8 +36,14 @@ const InputSchema = z.object({
       'Filter by type for `list`. `user` = your saved templates; `base` = Mailchimp starter layouts; `gallery` = paid drag-and-drop designs.',
     ),
   category: z.string().optional().describe('Category filter for `list`.'),
-  count: z.number().int().min(1).max(1000).default(20).describe('Page size for `list`. Max 1000.'),
-  offset: z.number().int().min(0).default(0).describe('Offset for `list` pagination.'),
+  count: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(1000)
+    .default(20)
+    .describe('Page size for `list`. Max 1000.'),
+  offset: z.coerce.number().int().min(0).default(0).describe('Offset for `list` pagination.'),
 });
 
 const TemplateSummarySchema = z.object({
@@ -97,7 +103,7 @@ function requireTemplateId(input: z.infer<typeof InputSchema>): number {
 
 export const mailchimpTemplatesTool = tool('mailchimp_templates', {
   description:
-    "Create, read, update, delete email templates. Free plan supports `base` (starter layouts) and `user` (your saved templates); `gallery` (paid drag-and-drop) will return a `Forbidden` error with `requiresPlan: 'standard'`. Deleting a template doesn't affect campaigns already built from it, so delete is safe to expose.",
+    "Create, read, update, delete email templates. Free plan supports `base` (starter layouts) and `user` (your saved templates); `gallery` (paid drag-and-drop) returns a `Forbidden` error with `requiresPlan: 'standard'`. Deleting a template doesn't affect campaigns already built from it, so delete is safe to expose. **Per-section editing is not supported here.** Mailchimp's templates PATCH endpoint only accepts `name`, `html`, and `folderId` — to change one block (e.g. the headline), GET the template, edit its HTML, then `update` with the full new HTML. Per-section overrides (by edit-region ID) live on campaigns built from a template, via `mailchimp_campaigns` (`set-content`) or `mailchimp_send_campaign` with `templateSections`.",
   annotations: { openWorldHint: true },
   input: InputSchema,
   output: OutputSchema,
@@ -144,7 +150,9 @@ export const mailchimpTemplatesTool = tool('mailchimp_templates', {
         if (input.html) body.html = input.html;
         if (input.folderId) body.folder_id = input.folderId;
         if (Object.keys(body).length === 0)
-          throw validationError('At least one of name/html/folderId must be provided for update.');
+          throw validationError(
+            'Provide at least one of `name`, `html`, or `folderId`. To edit one block of the template, GET the template, modify its HTML, then call `update` with the full new HTML — Mailchimp does not support patching individual sections here. Per-section overrides live on campaigns built from a template, via `mailchimp_campaigns` (`set-content`) or `mailchimp_send_campaign` with `templateSections`.',
+          );
         const t = await svc.templates.update(ctx, id, body);
         return { operation: 'update', template: summarize(t) };
       }
@@ -197,9 +205,16 @@ export const mailchimpTemplatesTool = tool('mailchimp_templates', {
     }
 
     if (result.defaultContent) {
-      lines.push('', '# Default content sections', '', '```json');
-      lines.push(JSON.stringify(result.defaultContent.sections ?? {}, null, 2));
-      lines.push('```');
+      const sections = result.defaultContent.sections ?? {};
+      const count = Object.keys(sections).length;
+      lines.push('', `# Default content sections (${count})`, '');
+      if (count === 0) {
+        lines.push(
+          '_No default sections recorded. Mailchimp only populates this map for drag-and-drop templates; for user-uploaded HTML templates that use `mc:edit`, read the HTML directly (`operation: get`) and pull the region names from the `mc:edit="…"` attributes. Use those names as the keys in `templateSections` when building a campaign from this template._',
+        );
+      } else {
+        lines.push('```json', JSON.stringify(sections, null, 2), '```');
+      }
     }
 
     if (typeof result.deleted === 'boolean') lines.push('', `_Deleted: ${result.deleted}_`);

--- a/src/mcp-server/tools/shared/template-sections-doc.ts
+++ b/src/mcp-server/tools/shared/template-sections-doc.ts
@@ -1,0 +1,22 @@
+/**
+ * @fileoverview Shared `.describe()` copy for the `templateSections` input
+ * field used by `mailchimp_send_campaign`, `mailchimp_campaigns`
+ * (`set-content`), and `mailchimp_replicate_campaign`. Keeping the text in
+ * one place prevents the three tools from drifting out of sync as the
+ * per-section override contract evolves.
+ * @module mcp-server/tools/shared/template-sections-doc
+ */
+
+export const TEMPLATE_SECTIONS_DOC = [
+  'Per-section HTML overrides for campaigns built from a saved template.',
+  'Keys are edit-region IDs — the `mc:edit="…"` attribute values in the template HTML,',
+  'or the section IDs returned by `mailchimp_templates` with `operation: get-default-content`.',
+  'Values are HTML strings that replace the default content for that region.',
+  'Only applied when `templateId` is also set; ignored otherwise.',
+  'Example: `{ "header": "<h1>Welcome</h1>", "body": "<p>…</p>" }`.',
+  'Note: Mailchimp only returns populated sections for drag-and-drop templates.',
+  'For user-uploaded HTML templates that use `mc:edit`, `get-default-content` often',
+  'returns an empty map; in that case, discover the region names by reading the',
+  "template's HTML (`mailchimp_templates` with `operation: get`) and pull the",
+  '`mc:edit` attribute values.',
+].join(' ');

--- a/tests/tools/input-coercion.test.ts
+++ b/tests/tools/input-coercion.test.ts
@@ -1,0 +1,186 @@
+/**
+ * @fileoverview Regression tests for the `z.coerce.number()` swap across every
+ * tool input schema that takes a numeric ID, page count, or offset. Before the
+ * swap these fields used `z.number()` which rejected string inputs — a common
+ * way MCP clients marshal integers over JSON-RPC, and the direct cause of a
+ * user-visible "expected number, received string" failure on any tool with a
+ * numeric parameter. These tests pin the behavior so it cannot silently
+ * regress across tools, imports, or future schema edits.
+ * @module tests/tools/input-coercion.test
+ */
+
+import { describe, expect, it } from 'vitest';
+import { mailchimpAudiencesTool } from '@/mcp-server/tools/definitions/mailchimp-audiences.tool.js';
+import { mailchimpCampaignsTool } from '@/mcp-server/tools/definitions/mailchimp-campaigns.tool.js';
+import { mailchimpMergeFieldsTool } from '@/mcp-server/tools/definitions/mailchimp-merge-fields.tool.js';
+import { mailchimpReplicateCampaignTool } from '@/mcp-server/tools/definitions/mailchimp-replicate-campaign.tool.js';
+import { mailchimpReportsTool } from '@/mcp-server/tools/definitions/mailchimp-reports.tool.js';
+import { mailchimpSearchTool } from '@/mcp-server/tools/definitions/mailchimp-search.tool.js';
+import { mailchimpSegmentsTool } from '@/mcp-server/tools/definitions/mailchimp-segments.tool.js';
+import { mailchimpSendCampaignTool } from '@/mcp-server/tools/definitions/mailchimp-send-campaign.tool.js';
+import { mailchimpSubscribersTool } from '@/mcp-server/tools/definitions/mailchimp-subscribers.tool.js';
+import { mailchimpTemplatesTool } from '@/mcp-server/tools/definitions/mailchimp-templates.tool.js';
+
+describe('input-coercion regression suite', () => {
+  it('templates: templateId/count/offset all accept strings', () => {
+    const parsed = mailchimpTemplatesTool.input.parse({
+      operation: 'get',
+      templateId: '999',
+      count: '50',
+      offset: '10',
+    });
+    expect(parsed.templateId).toBe(999);
+    expect(parsed.count).toBe(50);
+    expect(parsed.offset).toBe(10);
+  });
+
+  it('merge-fields: mergeId/displayOrder/count/offset all accept strings', () => {
+    const parsed = mailchimpMergeFieldsTool.input.parse({
+      operation: 'get',
+      audienceId: 'abc',
+      mergeId: '17',
+      displayOrder: '3',
+      count: '100',
+      offset: '20',
+    });
+    expect(parsed.mergeId).toBe(17);
+    expect(parsed.displayOrder).toBe(3);
+    expect(parsed.count).toBe(100);
+    expect(parsed.offset).toBe(20);
+  });
+
+  it('segments: segmentId/count/offset all accept strings', () => {
+    const parsed = mailchimpSegmentsTool.input.parse({
+      operation: 'get',
+      audienceId: 'abc',
+      segmentId: '42',
+      count: '25',
+      offset: '5',
+    });
+    expect(parsed.segmentId).toBe(42);
+    expect(parsed.count).toBe(25);
+    expect(parsed.offset).toBe(5);
+  });
+
+  it('subscribers: noteId/count/offset all accept strings', () => {
+    const parsed = mailchimpSubscribersTool.input.parse({
+      operation: 'update-note',
+      audienceId: 'abc',
+      email: 'user@example.com',
+      noteId: '7',
+      note: 'hello',
+      count: '30',
+      offset: '15',
+    });
+    expect(parsed.noteId).toBe(7);
+    expect(parsed.count).toBe(30);
+    expect(parsed.offset).toBe(15);
+  });
+
+  it('reports: count/offset accept strings', () => {
+    const parsed = mailchimpReportsTool.input.parse({
+      operation: 'list',
+      count: '40',
+      offset: '80',
+    });
+    expect(parsed.count).toBe(40);
+    expect(parsed.offset).toBe(80);
+  });
+
+  it('audiences: count/offset accept strings', () => {
+    const parsed = mailchimpAudiencesTool.input.parse({
+      operation: 'list',
+      count: '12',
+      offset: '24',
+    });
+    expect(parsed.count).toBe(12);
+    expect(parsed.offset).toBe(24);
+  });
+
+  it('campaigns: count/offset + nested templateId and savedSegmentId accept strings', () => {
+    const parsed = mailchimpCampaignsTool.input.parse({
+      operation: 'create',
+      type: 'regular',
+      recipients: {
+        listId: 'list1',
+        savedSegmentId: '99',
+      },
+      settings: {
+        subjectLine: 's',
+        templateId: '555',
+      },
+      content: {
+        templateId: '555',
+      },
+      count: '5',
+      offset: '0',
+    });
+    expect(parsed.recipients?.savedSegmentId).toBe(99);
+    expect(parsed.settings?.templateId).toBe(555);
+    expect(parsed.content?.templateId).toBe(555);
+    expect(parsed.count).toBe(5);
+    expect(parsed.offset).toBe(0);
+  });
+
+  it('send-campaign: content.templateId and segmentId accept strings', () => {
+    const parsed = mailchimpSendCampaignTool.input.parse({
+      audienceId: 'list1',
+      subject: 'hi',
+      fromName: 'me',
+      replyTo: 'me@example.com',
+      segmentId: '100',
+      content: {
+        templateId: '777',
+      },
+    });
+    expect(parsed.segmentId).toBe(100);
+    expect(parsed.content.templateId).toBe(777);
+  });
+
+  it('replicate-campaign: contentOverride.templateId and segmentOverride accept strings', () => {
+    const parsed = mailchimpReplicateCampaignTool.input.parse({
+      sourceCampaignId: 'src',
+      segmentOverride: '888',
+      contentOverride: {
+        templateId: '999',
+      },
+    });
+    expect(parsed.segmentOverride).toBe(888);
+    expect(parsed.contentOverride?.templateId).toBe(999);
+  });
+
+  it('search: includeTopN accepts strings', () => {
+    const parsed = mailchimpSearchTool.input.parse({
+      scope: 'members',
+      query: 'anna',
+      includeTopN: '25',
+    });
+    expect(parsed.includeTopN).toBe(25);
+  });
+
+  it('still rejects non-numeric strings', () => {
+    expect(() =>
+      mailchimpTemplatesTool.input.parse({ operation: 'get', templateId: 'abc' }),
+    ).toThrow();
+    expect(() =>
+      mailchimpCampaignsTool.input.parse({
+        operation: 'create',
+        type: 'regular',
+        recipients: { listId: 'l', savedSegmentId: 'xyz' },
+      }),
+    ).toThrow();
+  });
+
+  it('still enforces min/max on coerced numbers', () => {
+    expect(() =>
+      mailchimpTemplatesTool.input.parse({ operation: 'list', count: '5000' }),
+    ).toThrow();
+    expect(() =>
+      mailchimpSearchTool.input.parse({
+        scope: 'members',
+        query: 'x',
+        includeTopN: '0',
+      }),
+    ).toThrow();
+  });
+});

--- a/tests/tools/mailchimp-templates.test.ts
+++ b/tests/tools/mailchimp-templates.test.ts
@@ -1,0 +1,423 @@
+/**
+ * @fileoverview Tests for the `mailchimp_templates` tool. Covers the three
+ * regressions users surfaced during field testing:
+ *   1. Numeric input coercion (`templateId`, `count`, `offset` accepted as strings).
+ *   2. The update handler's actionable "at least one of …" validation error.
+ *   3. The `get-default-content` format hint when Mailchimp returns an empty
+ *      sections map (classic user-uploaded HTML templates using `mc:edit`).
+ * Plus end-to-end happy/edge paths for every operation with a stubbed fetch.
+ * @module tests/tools/mailchimp-templates.test
+ */
+
+import { JsonRpcErrorCode } from '@cyanheads/mcp-ts-core/errors';
+import { createMockContext } from '@cyanheads/mcp-ts-core/testing';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ServerConfig } from '@/config/server-config.js';
+import { mailchimpTemplatesTool } from '@/mcp-server/tools/definitions/mailchimp-templates.tool.js';
+import {
+  MailchimpService,
+  setMailchimpServiceForTesting,
+} from '@/services/mailchimp/mailchimp-service.js';
+
+const BASE_CONFIG: ServerConfig = {
+  apiKey: 'abcdef0123456789abcdef0123456789-us22',
+  baseUrl: 'https://us22.api.mailchimp.com/3.0',
+  timeoutMs: 1_000,
+  maxRetries: 0,
+  concurrencyLimit: 4,
+  dataCenter: 'us22',
+};
+
+function fakeResponse(status: number, body: unknown = ''): Response {
+  const text = typeof body === 'string' ? body : JSON.stringify(body);
+  return new Response(text, {
+    status,
+    statusText: status >= 200 && status < 300 ? 'OK' : 'Error',
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+const TEMPLATE_FIXTURE = {
+  id: 10012367,
+  name: 'Newsletter — Spring',
+  type: 'user',
+  created_by: 'tester',
+  date_created: '2026-04-21T21:31:30+00:00',
+  date_edited: '2026-04-21T21:31:30+00:00',
+  active: true,
+  drag_and_drop: false,
+  responsive: true,
+} as const;
+
+describe('mailchimpTemplatesTool — input schema coercion', () => {
+  it('coerces string templateId to number (operation: get)', () => {
+    const parsed = mailchimpTemplatesTool.input.parse({
+      operation: 'get',
+      templateId: '10012367',
+    });
+    expect(parsed.templateId).toBe(10012367);
+    expect(typeof parsed.templateId).toBe('number');
+  });
+
+  it('coerces string count and offset (operation: list)', () => {
+    const parsed = mailchimpTemplatesTool.input.parse({
+      operation: 'list',
+      count: '50',
+      offset: '100',
+    });
+    expect(parsed.count).toBe(50);
+    expect(parsed.offset).toBe(100);
+  });
+
+  it('applies defaults for count/offset when omitted', () => {
+    const parsed = mailchimpTemplatesTool.input.parse({ operation: 'list' });
+    expect(parsed.count).toBe(20);
+    expect(parsed.offset).toBe(0);
+  });
+
+  it('rejects non-numeric templateId strings', () => {
+    expect(() =>
+      mailchimpTemplatesTool.input.parse({ operation: 'get', templateId: 'not-a-number' }),
+    ).toThrow();
+  });
+
+  it('rejects count above the 1000 max even when passed as string', () => {
+    expect(() =>
+      mailchimpTemplatesTool.input.parse({ operation: 'list', count: '9999' }),
+    ).toThrow();
+  });
+
+  it('rejects negative offsets', () => {
+    expect(() => mailchimpTemplatesTool.input.parse({ operation: 'list', offset: '-1' })).toThrow();
+  });
+});
+
+describe('mailchimpTemplatesTool — handler', () => {
+  beforeEach(() => {
+    setMailchimpServiceForTesting(new MailchimpService(BASE_CONFIG));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    setMailchimpServiceForTesting(undefined);
+  });
+
+  it('list: returns summarized templates and totalItems', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        fakeResponse(200, {
+          templates: [TEMPLATE_FIXTURE],
+          total_items: 1,
+        }),
+      ),
+    );
+    const input = mailchimpTemplatesTool.input.parse({ operation: 'list' });
+    const result = await mailchimpTemplatesTool.handler(input, createMockContext());
+    expect(result.operation).toBe('list');
+    expect(result.totalItems).toBe(1);
+    expect(result.templates).toHaveLength(1);
+    expect(result.templates?.[0]?.id).toBe(10012367);
+    expect(result.templates?.[0]?.name).toBe('Newsletter — Spring');
+  });
+
+  it('list: forwards type and category filters to the upstream query', async () => {
+    const stub = vi.fn(async () => fakeResponse(200, { templates: [], total_items: 0 }));
+    vi.stubGlobal('fetch', stub);
+    const input = mailchimpTemplatesTool.input.parse({
+      operation: 'list',
+      type: 'user',
+      category: 'promos',
+    });
+    await mailchimpTemplatesTool.handler(input, createMockContext());
+    const url = String(stub.mock.calls[0]?.[0]);
+    expect(url).toContain('type=user');
+    expect(url).toContain('category=promos');
+  });
+
+  it('get: calls GET /templates/{id} and returns a summarized template', async () => {
+    const stub = vi.fn(async (input: RequestInfo | URL) => {
+      expect(String(input)).toContain('/templates/10012367');
+      return fakeResponse(200, TEMPLATE_FIXTURE);
+    });
+    vi.stubGlobal('fetch', stub);
+    const input = mailchimpTemplatesTool.input.parse({
+      operation: 'get',
+      templateId: '10012367', // string — regression guard
+    });
+    const result = await mailchimpTemplatesTool.handler(input, createMockContext());
+    expect(stub).toHaveBeenCalledOnce();
+    expect(result.operation).toBe('get');
+    expect(result.template?.id).toBe(10012367);
+  });
+
+  it('create: requires name', async () => {
+    vi.stubGlobal('fetch', vi.fn());
+    const input = mailchimpTemplatesTool.input.parse({
+      operation: 'create',
+      html: '<h1>x</h1>',
+    });
+    await expect(mailchimpTemplatesTool.handler(input, createMockContext())).rejects.toMatchObject({
+      code: JsonRpcErrorCode.ValidationError,
+      message: expect.stringContaining("'name' is required"),
+    });
+  });
+
+  it('create: requires html', async () => {
+    vi.stubGlobal('fetch', vi.fn());
+    const input = mailchimpTemplatesTool.input.parse({
+      operation: 'create',
+      name: 'New Template',
+    });
+    await expect(mailchimpTemplatesTool.handler(input, createMockContext())).rejects.toMatchObject({
+      code: JsonRpcErrorCode.ValidationError,
+      message: expect.stringContaining("'html' is required"),
+    });
+  });
+
+  it('create: POSTs to /templates and surfaces the returned template', async () => {
+    const stub = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(String(input)).toMatch(/\/templates$/);
+      expect(init?.method).toBe('POST');
+      const body = JSON.parse(String(init?.body));
+      expect(body).toEqual({ name: 'New Template', html: '<h1>x</h1>' });
+      return fakeResponse(200, { ...TEMPLATE_FIXTURE, id: 2222222, name: 'New Template' });
+    });
+    vi.stubGlobal('fetch', stub);
+    const input = mailchimpTemplatesTool.input.parse({
+      operation: 'create',
+      name: 'New Template',
+      html: '<h1>x</h1>',
+    });
+    const result = await mailchimpTemplatesTool.handler(input, createMockContext());
+    expect(result.template?.id).toBe(2222222);
+  });
+
+  it('update with just name: sends PATCH with only { name }', async () => {
+    const stub = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      expect(init?.method).toBe('PATCH');
+      const body = JSON.parse(String(init?.body));
+      expect(body).toEqual({ name: 'Renamed' });
+      return fakeResponse(200, { ...TEMPLATE_FIXTURE, name: 'Renamed' });
+    });
+    vi.stubGlobal('fetch', stub);
+    const input = mailchimpTemplatesTool.input.parse({
+      operation: 'update',
+      templateId: '10012367',
+      name: 'Renamed',
+    });
+    const result = await mailchimpTemplatesTool.handler(input, createMockContext());
+    expect(result.operation).toBe('update');
+    expect(result.template?.name).toBe('Renamed');
+  });
+
+  it('update with just html: sends PATCH with only { html }', async () => {
+    const stub = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body).toEqual({ html: '<h1>new</h1>' });
+      return fakeResponse(200, TEMPLATE_FIXTURE);
+    });
+    vi.stubGlobal('fetch', stub);
+    const input = mailchimpTemplatesTool.input.parse({
+      operation: 'update',
+      templateId: '10012367',
+      html: '<h1>new</h1>',
+    });
+    await mailchimpTemplatesTool.handler(input, createMockContext());
+    expect(stub).toHaveBeenCalledOnce();
+  });
+
+  it('update with all three fields: forwards each as Mailchimp expects (folder_id snake_case)', async () => {
+    const stub = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body).toEqual({ name: 'n', html: '<h1>h</h1>', folder_id: 'f123' });
+      return fakeResponse(200, TEMPLATE_FIXTURE);
+    });
+    vi.stubGlobal('fetch', stub);
+    const input = mailchimpTemplatesTool.input.parse({
+      operation: 'update',
+      templateId: '10012367',
+      name: 'n',
+      html: '<h1>h</h1>',
+      folderId: 'f123',
+    });
+    await mailchimpTemplatesTool.handler(input, createMockContext());
+  });
+
+  it('update with no name/html/folderId: throws a descriptive validation error and does NOT call upstream', async () => {
+    const stub = vi.fn();
+    vi.stubGlobal('fetch', stub);
+    const input = mailchimpTemplatesTool.input.parse({
+      operation: 'update',
+      templateId: '10012367',
+    });
+    await expect(mailchimpTemplatesTool.handler(input, createMockContext())).rejects.toMatchObject({
+      code: JsonRpcErrorCode.ValidationError,
+      message: expect.stringContaining('Per-section overrides live on campaigns'),
+    });
+    expect(stub).not.toHaveBeenCalled();
+  });
+
+  it('update without templateId: throws the templateId-required validation error', async () => {
+    vi.stubGlobal('fetch', vi.fn());
+    const input = mailchimpTemplatesTool.input.parse({
+      operation: 'update',
+      name: 'Renamed',
+    });
+    await expect(mailchimpTemplatesTool.handler(input, createMockContext())).rejects.toMatchObject({
+      code: JsonRpcErrorCode.ValidationError,
+      message: expect.stringContaining("'templateId' is required"),
+    });
+  });
+
+  it('delete: issues DELETE and sets deleted=true', async () => {
+    const stub = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      expect(init?.method).toBe('DELETE');
+      return fakeResponse(204, '');
+    });
+    vi.stubGlobal('fetch', stub);
+    const input = mailchimpTemplatesTool.input.parse({
+      operation: 'delete',
+      templateId: '10012367',
+    });
+    const result = await mailchimpTemplatesTool.handler(input, createMockContext());
+    expect(result.deleted).toBe(true);
+  });
+
+  it('get-default-content: returns sections map when Mailchimp provides one', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        fakeResponse(200, {
+          sections: { headline: '<h1>Welcome</h1>', body: '<p>Hi</p>' },
+        }),
+      ),
+    );
+    const input = mailchimpTemplatesTool.input.parse({
+      operation: 'get-default-content',
+      templateId: '10012367',
+    });
+    const result = await mailchimpTemplatesTool.handler(input, createMockContext());
+    expect(result.defaultContent?.sections).toEqual({
+      headline: '<h1>Welcome</h1>',
+      body: '<p>Hi</p>',
+    });
+  });
+
+  it('get-default-content: returns empty defaultContent object when Mailchimp returns no sections', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => fakeResponse(200, { sections: {} })),
+    );
+    const input = mailchimpTemplatesTool.input.parse({
+      operation: 'get-default-content',
+      templateId: '10012367',
+    });
+    const result = await mailchimpTemplatesTool.handler(input, createMockContext());
+    // Empty object sections is truthy → forwarded; format handles the hint.
+    expect(result.defaultContent).toEqual({ sections: {} });
+  });
+});
+
+describe('mailchimpTemplatesTool — metadata', () => {
+  it('tool description calls out that per-section patching is not supported here', () => {
+    expect(mailchimpTemplatesTool.description).toContain('Per-section editing is not supported');
+    // Directs callers to the correct workflow for per-section edits.
+    expect(mailchimpTemplatesTool.description).toContain('mailchimp_campaigns');
+    expect(mailchimpTemplatesTool.description).toContain('templateSections');
+  });
+});
+
+describe('mailchimpTemplatesTool — format', () => {
+  it('renders a list with counts', () => {
+    const text = mailchimpTemplatesTool.format(
+      {
+        operation: 'list',
+        totalItems: 3,
+        templates: [
+          {
+            id: 1,
+            name: 'A',
+            type: 'user',
+            dateCreated: '2026-01-01T00:00:00+00:00',
+            active: true,
+          },
+        ],
+      },
+      createMockContext(),
+    );
+    const block = text[0];
+    if (!block || block.type !== 'text') throw new Error('expected text block');
+    expect(block.text).toContain('# Templates (1 of 3)');
+    expect(block.text).toContain('**A**');
+  });
+
+  it('renders a detail with metadata and flags', () => {
+    const text = mailchimpTemplatesTool.format(
+      {
+        operation: 'get',
+        template: {
+          id: 10012367,
+          name: 'Renamed',
+          type: 'user',
+          createdBy: 'tester',
+          dateCreated: '2026-04-21T21:31:30+00:00',
+          active: true,
+          dragAndDrop: false,
+          responsive: true,
+        },
+      },
+      createMockContext(),
+    );
+    const block = text[0];
+    if (!block || block.type !== 'text') throw new Error('expected text block');
+    expect(block.text).toContain('# Renamed');
+    expect(block.text).toContain('10012367');
+    expect(block.text).toContain('dragAndDrop false');
+    expect(block.text).toContain('responsive true');
+  });
+
+  it('default-content: shows the hint when sections map is empty', () => {
+    const text = mailchimpTemplatesTool.format(
+      {
+        operation: 'get-default-content',
+        defaultContent: { sections: {} },
+      },
+      createMockContext(),
+    );
+    const block = text[0];
+    if (!block || block.type !== 'text') throw new Error('expected text block');
+    expect(block.text).toContain('Default content sections (0)');
+    expect(block.text).toContain('Mailchimp only populates this map for drag-and-drop templates');
+    expect(block.text).toContain('`mc:edit="…"`');
+    expect(block.text).toContain('templateSections');
+  });
+
+  it('default-content: shows sections as JSON when populated', () => {
+    const text = mailchimpTemplatesTool.format(
+      {
+        operation: 'get-default-content',
+        defaultContent: {
+          sections: { headline: '<h1>Welcome</h1>' },
+        },
+      },
+      createMockContext(),
+    );
+    const block = text[0];
+    if (!block || block.type !== 'text') throw new Error('expected text block');
+    expect(block.text).toContain('Default content sections (1)');
+    expect(block.text).toContain('```json');
+    expect(block.text).toContain('"headline"');
+    expect(block.text).toContain('<h1>Welcome</h1>');
+  });
+
+  it('delete: shows deleted marker', () => {
+    const text = mailchimpTemplatesTool.format(
+      { operation: 'delete', deleted: true },
+      createMockContext(),
+    );
+    const block = text[0];
+    if (!block || block.type !== 'text') throw new Error('expected text block');
+    expect(block.text).toContain('_Deleted: true_');
+  });
+});

--- a/tests/tools/template-sections-doc.test.ts
+++ b/tests/tools/template-sections-doc.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @fileoverview Regression tests for the shared `templateSections` describe
+ * string used by `mailchimp_send_campaign`, `mailchimp_campaigns`, and
+ * `mailchimp_replicate_campaign`. Before this was shared, one of the three
+ * tools had no `.describe()` at all and the other two had thin descriptions
+ * that didn't explain the key/value contract — the likely root cause of the
+ * "gets null set" failure users reported. These tests pin:
+ *   1. The shared doc exists and covers every element the LLM needs to call
+ *      the tool correctly (keys, values, discovery, example, caveat).
+ *   2. All three tools actually surface that doc on the right field.
+ * @module tests/tools/template-sections-doc.test
+ */
+
+import { z } from '@cyanheads/mcp-ts-core';
+import { describe, expect, it } from 'vitest';
+import { mailchimpCampaignsTool } from '@/mcp-server/tools/definitions/mailchimp-campaigns.tool.js';
+import { mailchimpReplicateCampaignTool } from '@/mcp-server/tools/definitions/mailchimp-replicate-campaign.tool.js';
+import { mailchimpSendCampaignTool } from '@/mcp-server/tools/definitions/mailchimp-send-campaign.tool.js';
+import { TEMPLATE_SECTIONS_DOC } from '@/mcp-server/tools/shared/template-sections-doc.js';
+
+describe('TEMPLATE_SECTIONS_DOC', () => {
+  it('mentions the edit-region key source (`mc:edit` and get-default-content)', () => {
+    expect(TEMPLATE_SECTIONS_DOC).toContain('mc:edit');
+    expect(TEMPLATE_SECTIONS_DOC).toContain('get-default-content');
+  });
+
+  it('states the value type (HTML strings) and when it applies', () => {
+    expect(TEMPLATE_SECTIONS_DOC).toContain('HTML');
+    expect(TEMPLATE_SECTIONS_DOC).toContain('templateId');
+  });
+
+  it('includes a concrete example', () => {
+    expect(TEMPLATE_SECTIONS_DOC).toContain('header');
+    expect(TEMPLATE_SECTIONS_DOC).toContain('<h1>');
+  });
+
+  it('warns about empty sections on non-drag-and-drop templates', () => {
+    expect(TEMPLATE_SECTIONS_DOC).toMatch(/drag-and-drop|classic|user-uploaded/i);
+  });
+});
+
+/**
+ * Read a nested `description` out of a JSON Schema document produced by
+ * `z.toJSONSchema`. Walks through `properties` at each path segment, and
+ * unwraps `allOf` / `$defs` / `anyOf` wrappers Zod uses to represent
+ * `.optional()` on object properties. Returns the first description found
+ * at the target path.
+ */
+function jsonSchemaDescription(schema: unknown, path: readonly string[]): string | undefined {
+  const resolve = (node: unknown): unknown => {
+    if (!node || typeof node !== 'object') return node;
+    const n = node as Record<string, unknown>;
+    if (Array.isArray(n['allOf']) && n['allOf'].length > 0) {
+      return { ...n, ...resolve(n['allOf'][0]) };
+    }
+    if (Array.isArray(n['anyOf']) && n['anyOf'].length > 0) {
+      return { ...n, ...resolve(n['anyOf'][0]) };
+    }
+    return n;
+  };
+  let node: Record<string, unknown> | undefined = resolve(schema) as
+    | Record<string, unknown>
+    | undefined;
+  for (const segment of path) {
+    if (!node) return;
+    const props = node['properties'];
+    if (!props || typeof props !== 'object') return;
+    const next = (props as Record<string, unknown>)[segment];
+    node = resolve(next) as Record<string, unknown> | undefined;
+  }
+  const desc = node?.['description'];
+  return typeof desc === 'string' ? desc : undefined;
+}
+
+describe('templateSections field surfaces TEMPLATE_SECTIONS_DOC', () => {
+  it('mailchimp_send_campaign: content.templateSections', () => {
+    const schema = z.toJSONSchema(mailchimpSendCampaignTool.input);
+    expect(jsonSchemaDescription(schema, ['content', 'templateSections'])).toBe(
+      TEMPLATE_SECTIONS_DOC,
+    );
+  });
+
+  it('mailchimp_campaigns: content.templateSections', () => {
+    const schema = z.toJSONSchema(mailchimpCampaignsTool.input);
+    expect(jsonSchemaDescription(schema, ['content', 'templateSections'])).toBe(
+      TEMPLATE_SECTIONS_DOC,
+    );
+  });
+
+  it('mailchimp_replicate_campaign: contentOverride.templateSections', () => {
+    const schema = z.toJSONSchema(mailchimpReplicateCampaignTool.input);
+    expect(jsonSchemaDescription(schema, ['contentOverride', 'templateSections'])).toBe(
+      TEMPLATE_SECTIONS_DOC,
+    );
+  });
+});


### PR DESCRIPTION
Addresses three issues surfaced during field-testing the templates surface — one blocking schema bug that affected every tool taking a numeric ID, and two UX issues on the templates/campaign-content workflow that drove a user report about "expecting an array of IDs per text box but getting null set".

## Changes

| # | Issue | Fix |
|:--|:------|:----|
| [#3](https://github.com/cyanheads/mailchimp-mcp-server/issues/3) | Numeric IDs rejected when serialized as strings | Every input-side `z.number().int()` is now `z.coerce.number().int()` across 10 tools. Output schemas unchanged. |
| [#4](https://github.com/cyanheads/mailchimp-mcp-server/issues/4) | `templateSections` field had no usable description | Shared `TEMPLATE_SECTIONS_DOC` with keys/values/example/discovery/caveat, wired into `send_campaign`, `campaigns` `set-content`, and `replicate_campaign`'s `contentOverride`. |
| [#5](https://github.com/cyanheads/mailchimp-mcp-server/issues/5) | Templates tool didn't explain "no per-section patching" | Tool description + `update` validation error + `get-default-content` format hint all now point callers to the campaign workflow for per-section edits. |

## Test coverage

- `tests/tools/input-coercion.test.ts` (12 cases) — pins string-coercion across every affected tool.
- `tests/tools/mailchimp-templates.test.ts` (26 cases) — full CRUD + error paths + format + metadata for the templates tool.
- `tests/tools/template-sections-doc.test.ts` (7 cases) — asserts shared doc content and that all three campaign-content tools emit it in their JSON Schema.

**Total: 95/95 tests passing** (up from 50). `bun run devcheck` clean, `bun run lint:mcp` clean, `bun run rebuild` clean.

## Live-verified via MCP after rebuild

| Scenario | Pre-fix | Post-fix |
|:---|:---|:---|
| `get` with `templateId: "10012368"` (string) | schema rejection before handler | ✅ |
| `update` with only `name` | schema rejection before handler | ✅ renames |
| `update` with only `html` | schema rejection before handler | ✅ updates |
| `update` with nothing | generic "at least one of" | ✅ actionable error pointing to `templateSections` workflow |
| `get-default-content` | schema rejection before handler | ✅ returns populated sections |
| `delete` | worked | ✅ still works |

## Version

Patch bump: **0.2.6 → 0.2.7** (package.json, server.json x3, README badge, CLAUDE.md header, CHANGELOG entry, docs/tree.md).

## Commits

1. `fix(schema): coerce numeric inputs across read tools` — audiences/merge-fields/reports/search/segments/subscribers + regression test
2. `fix(campaigns): document templateSections contract on campaign-content tools` — shared doc + 3 campaign tools + wiring test
3. `fix(templates): explain no per-section patching; add coerce + empty-sections hint` — templates tool + comprehensive test suite
4. `chore(release): 0.2.7` — version bump + CHANGELOG + tree